### PR TITLE
QOL GUI Patch

### DIFF
--- a/src/pytribeam/GUI/CustomTkinterWidgets/button.py
+++ b/src/pytribeam/GUI/CustomTkinterWidgets/button.py
@@ -24,7 +24,6 @@ class Button(tk.Button):
         self.a_fg = h_fg or fg
         self.a_bg = h_bg or bg
         self.text = text
-        print(f"{self.text} creation", self.bg)
         kw.update(
             dict(
                 text=self.text,
@@ -41,14 +40,10 @@ class Button(tk.Button):
         self.bind("<Leave>", self.on_leave)
 
     def on_enter(self, e):
-        self.bg, self.a_bg = self.a_bg, self.bg
-        self.fg, self.a_fg = self.a_fg, self.fg
-        self.config(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
+        self.configure(bg=self.a_bg, fg=self.a_fg, activebackground=self.a_bg, activeforeground=self.a_fg)
 
     def on_leave(self, e):
-        self.bg, self.a_bg = self.a_bg, self.bg
-        self.fg, self.a_fg = self.a_fg, self.fg
-        self.config(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
+        self.configure(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
 
     def config(self, *args, **kwargs):
         if "bg" in kwargs:

--- a/src/pytribeam/GUI/CustomTkinterWidgets/button.py
+++ b/src/pytribeam/GUI/CustomTkinterWidgets/button.py
@@ -40,10 +40,20 @@ class Button(tk.Button):
         self.bind("<Leave>", self.on_leave)
 
     def on_enter(self, e):
-        self.configure(bg=self.a_bg, fg=self.a_fg, activebackground=self.a_bg, activeforeground=self.a_fg)
+        self.configure(
+            bg=self.a_bg,
+            fg=self.a_fg,
+            activebackground=self.a_bg,
+            activeforeground=self.a_fg,
+        )
 
     def on_leave(self, e):
-        self.configure(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
+        self.configure(
+            bg=self.bg,
+            fg=self.fg,
+            activebackground=self.a_bg,
+            activeforeground=self.a_fg,
+        )
 
     def config(self, *args, **kwargs):
         if "bg" in kwargs:
@@ -55,6 +65,7 @@ class Button(tk.Button):
         if "activeforeground" in kwargs:
             self.a_fg = kwargs["activeforeground"]
         self.configure(*args, **kwargs)
+
 
 class Button3d(ttk.Button):
     """create a button with 3d background color and shadow"""

--- a/src/pytribeam/GUI/CustomTkinterWidgets/button.py
+++ b/src/pytribeam/GUI/CustomTkinterWidgets/button.py
@@ -19,18 +19,20 @@ class Button(tk.Button):
 
         self.bg = bg or get_widget_attribute(parent, "background")
         self.fg = fg or calc_font_color(self.bg)
-        h_bg = h_bg or bg
-        h_fg = h_fg or fg
-        a_fg = h_fg or fg
-        a_bg = h_bg or bg
+        self.h_bg = h_bg or bg
+        self.h_fg = h_fg or fg
+        self.a_fg = h_fg or fg
+        self.a_bg = h_bg or bg
+        self.text = text
+        print(f"{self.text} creation", self.bg)
         kw.update(
             dict(
-                text=text,
+                text=self.text,
                 bg=self.bg,
                 fg=self.fg,
-                highlightcolor=h_bg,
-                activebackground=a_bg,
-                activeforeground=a_fg,
+                highlightcolor=self.h_bg,
+                activebackground=self.a_bg,
+                activeforeground=self.a_fg,
                 command=command,
             )
         )
@@ -39,11 +41,25 @@ class Button(tk.Button):
         self.bind("<Leave>", self.on_leave)
 
     def on_enter(self, e):
-        self.config(bg=self["activebackground"], fg=self["activeforeground"])
+        self.bg, self.a_bg = self.a_bg, self.bg
+        self.fg, self.a_fg = self.a_fg, self.fg
+        self.config(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
 
     def on_leave(self, e):
-        self.config(bg=self.bg, fg=self.fg)
+        self.bg, self.a_bg = self.a_bg, self.bg
+        self.fg, self.a_fg = self.a_fg, self.fg
+        self.config(bg=self.bg, fg=self.fg, activebackground=self.a_bg, activeforeground=self.a_fg)
 
+    def config(self, *args, **kwargs):
+        if "bg" in kwargs:
+            self.bg = kwargs["bg"]
+        if "fg" in kwargs:
+            self.fg = kwargs["fg"]
+        if "activebackground" in kwargs:
+            self.a_bg = kwargs["activebackground"]
+        if "activeforeground" in kwargs:
+            self.a_fg = kwargs["activeforeground"]
+        self.configure(*args, **kwargs)
 
 class Button3d(ttk.Button):
     """create a button with 3d background color and shadow"""

--- a/src/pytribeam/GUI/CustomTkinterWidgets/menu.py
+++ b/src/pytribeam/GUI/CustomTkinterWidgets/menu.py
@@ -111,3 +111,13 @@ class RightClickMenu(tk.Menu):
 
         if callable(self.callback):
             self.callback(option)
+
+    def remove(self):
+        for i in [1, 2, 3]:
+            if i == 1 and self.parent.winfo_class() == "Button":
+                self.parent["command"] = None
+                continue
+            self.parent.unbind(f"<Button-{i}>")
+            self.unbind(f"<{i}>")
+            self.unbind(f"<ButtonRelease-{i}>")
+        self.destroy()

--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -1002,7 +1002,7 @@ class Configurator:
             _, row = self.pipeline.grid_size()
         except tk.TclError:
             return
-        
+
         # Create kwargs
         kw_current = {
             "font": ctk.FONT,

--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -439,10 +439,13 @@ class Configurator:
 
     def _on_step_removed(self, index):
         """Handle step removal."""
-        self._update_pipeline()
         # Select general or previous step
-        new_index = max(0, index - 1)
-        self.controller.select_step(new_index)
+        if index == self.STEP_INDEX:
+            self.controller.select_step(0)
+        elif index < self.STEP_INDEX:
+            self.controller.select_step(self.STEP_INDEX - 1)
+        else:
+            self.controller.select_step(self.STEP_INDEX)
 
     def _on_parameter_changed(self, path, value):
         """Handle parameter change from controller."""
@@ -1029,14 +1032,13 @@ class Configurator:
                 "Delete": lambda x=i: self.delete_pipeline_step(x),
                 "Duplicate": lambda x=i: self.duplicate_pipeline_step(x),
             }
-            right_click_states = ["normal", "normal", "normal", "normal"]
             if i == 1:
-                right_click_states[0] = "disabled"
-            if i == len(options) - 1:
-                right_click_states[1] = "disabled"
+                right_click_map.pop("Move up")
+            if i != 0 and i == len(options) - 1:
+                right_click_map.pop("Move down")
 
             # If the row is the end of the pipeline, create a new button
-            if row_i >= row or i == self.STEP_INDEX:
+            if row_i >= row:
                 button = ctk.Button(
                     self.pipeline,
                     text=option,
@@ -1048,16 +1050,6 @@ class Configurator:
                 button.grid(
                     row=row_i, column=0, columnspan=2, sticky="nsew", pady=1, padx=1
                 )
-                # Add the right click menu to the button
-                if i != 0:
-                    button.right_click_menu = ctk.RightClickMenu(
-                        button,
-                        right_click_map.keys(),
-                        bg=self.theme.bg,
-                        fg=self.theme.fg,
-                        abg=self.theme.accent1,
-                        afg=self.theme.fg,
-                    )
 
             # If the row is not the end of the pipeline, update the button with the new option (in case it has changed)
             else:
@@ -1070,13 +1062,22 @@ class Configurator:
 
             # Change the state of the commands in the right click menu based on position
             if i != 0:
-                for j, state in enumerate(right_click_states):
-                    key = list(right_click_map.keys())[j]
+                if hasattr(button, "right_click_menu"):
+                    button.right_click_menu.remove()
+                button.right_click_menu = ctk.RightClickMenu(
+                    button,
+                    right_click_map.keys(),
+                    bg=self.theme.bg,
+                    fg=self.theme.fg,
+                    abg=self.theme.accent1,
+                    afg=self.theme.fg,
+                )
+                for j, key in enumerate(right_click_map.keys()):
                     button.right_click_menu.entryconfig(
                         index=j,
                         label=f" {key}",
                         command=right_click_map[key],
-                        state=state,
+                        state="normal",
                     )
 
         # If the pipeline is longer than the options, delete the extra rows

--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -999,29 +999,28 @@ class Configurator:
             _, row = self.pipeline.grid_size()
         except tk.TclError:
             return
+        
+        # Create kwargs
+        kw_current = {
+            "font": ctk.FONT,
+            "relief": "raised",
+            "bg": self.theme.accent1,
+            "fg": self.theme.accent1_fg,
+            "activebackground": self.theme.accent1,
+            "activeforeground": self.theme.accent1_fg,
+        }
+        kw_other = {
+            "font": ctk.FONT,
+            "relief": "groove",
+            "bg": self.theme.bg,
+            "fg": self.theme.fg,
+            "activebackground": self.theme.accent1,
+            "activeforeground": self.theme.accent1_fg,
+        }
+
         # Loop over the options and update the pipeline
         for i, option in enumerate(options):
             row_i = i + 2
-
-            # Set the text to be displayed and the colors
-            if i == self.STEP_INDEX:
-                kw = {
-                    "font": ctk.FONT,
-                    "relief": "raised",
-                    "bg": self.theme.accent1,
-                    "fg": self.theme.accent1_fg,
-                    "activebackground": self.theme.accent1,
-                    "activeforeground": self.theme.accent1_fg,
-                }
-            else:
-                kw = {
-                    "font": ctk.FONT,
-                    "relief": "groove",
-                    "bg": self.theme.bg,
-                    "fg": self.theme.fg,
-                    "activebackground": self.theme.accent1,
-                    "activeforeground": self.theme.accent1_fg,
-                }
 
             # Create tooltip options and state
             right_click_map = {
@@ -1044,7 +1043,7 @@ class Configurator:
                     padx=5,
                     bd=3,
                     command=lambda a=option: self.select_pipeline_step(a),
-                    **kw,
+                    **kw_other,
                 )
                 button.grid(
                     row=row_i, column=0, columnspan=2, sticky="nsew", pady=1, padx=1
@@ -1066,7 +1065,7 @@ class Configurator:
                 button.config(
                     text=option,
                     command=lambda a=option: self.select_pipeline_step(a),
-                    **kw,
+                    **kw_other,
                 )
 
             # Change the state of the commands in the right click menu based on position
@@ -1085,10 +1084,14 @@ class Configurator:
             for i in range(len(options) + 2, row):
                 for widget in self.pipeline.grid_slaves(row=i):
                     widget.destroy()
+
         # Bind mouse scroll to the scrollable frame, but make sure the children also have the binding
         ctk.utils.scroll_with_mousewheel(
             self.pipeline, self.pipeline.canvas, apply_to_children=True
         )
+
+        # Highlight the current step
+        self.pipeline.grid_slaves(self.STEP_INDEX + 2)[0].config(**kw_current)
 
     # -------- Editor Operations -------- #
 

--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -434,7 +434,8 @@ class Configurator:
 
     def _on_step_added(self, step):
         """Handle step addition."""
-        self._update_pipeline()
+        pass
+        # self._update_pipeline()
 
     def _on_step_removed(self, index):
         """Handle step removal."""
@@ -1007,10 +1008,8 @@ class Configurator:
                 kw = {
                     "font": ctk.FONT,
                     "relief": "raised",
-                    "bg": self.theme.bg,
-                    "fg": self.theme.fg,
-                    # "h_bg": self.theme.accent1,
-                    # "h_fg": self.theme.accent1_fg,
+                    "bg": self.theme.accent1,
+                    "fg": self.theme.accent1_fg,
                     "activebackground": self.theme.accent1,
                     "activeforeground": self.theme.accent1_fg,
                 }
@@ -1020,9 +1019,8 @@ class Configurator:
                     "relief": "groove",
                     "bg": self.theme.bg,
                     "fg": self.theme.fg,
-                    # "highlightcolor": self.theme.accent1,
-                    "activebackground": self.theme.bg,
-                    "activeforeground": self.theme.fg,
+                    "activebackground": self.theme.accent1,
+                    "activeforeground": self.theme.accent1_fg,
                 }
 
             # Create tooltip options and state


### PR DESCRIPTION
Configurator GUI was updated based on user feedback.

- Active step is now highlighted by an accent color to more clearly distinguish which step is currently being edited.
- Hovering over non-active steps highlights them now. Providing clear indication of which step you are selecting.
- Deleting steps now works for all cases (deleting active step, deleting prior step, deleting later step) with expected behavior.
- Right click menus now do not show illegal movements (i.e. last step moving later cannot happen). Before, those movements were shown but disabled.