### PR TITLE
Import angular correction parameters in imaging conditions

### DIFF
--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -632,6 +632,15 @@ class Configurator:
                 f"{pkey}beam/working_dist_mm",
                 imaging_settings.beam.settings.working_dist_mm,
             )
+            if self.STEP != "fib":
+                self.controller.update_parameter(
+                    f"{pkey}beam/dynamic_focus",
+                    imaging_settings.beam.settings.dynamic_focus,
+                )
+                self.controller.update_parameter(
+                    f"{pkey}beam/tilt_correction",
+                    imaging_settings.beam.settings.tilt_correction,
+                )
             if "mill" not in pkey:
                 self.controller.update_parameter(
                     f"{pkey}detector/type",

--- a/src/pytribeam/GUI/config_ui/App.py
+++ b/src/pytribeam/GUI/config_ui/App.py
@@ -632,15 +632,15 @@ class Configurator:
                 f"{pkey}beam/working_dist_mm",
                 imaging_settings.beam.settings.working_dist_mm,
             )
-            if self.STEP != "fib":
-                self.controller.update_parameter(
-                    f"{pkey}beam/dynamic_focus",
-                    imaging_settings.beam.settings.dynamic_focus,
-                )
-                self.controller.update_parameter(
-                    f"{pkey}beam/tilt_correction",
-                    imaging_settings.beam.settings.tilt_correction,
-                )
+            # if self.STEP != "fib":
+            self.controller.update_parameter(
+                f"{pkey}beam/dynamic_focus",
+                imaging_settings.beam.settings.dynamic_focus,
+            )
+            self.controller.update_parameter(
+                f"{pkey}beam/tilt_correction",
+                imaging_settings.beam.settings.tilt_correction,
+            )
             if "mill" not in pkey:
                 self.controller.update_parameter(
                     f"{pkey}detector/type",

--- a/src/pytribeam/factory.py
+++ b/src/pytribeam/factory.py
@@ -219,6 +219,14 @@ def active_beam_with_settings(
 
     working_dist_mm = round(beam.working_distance.value * Conversions.M_TO_MM, 6)
 
+    angular_correction = getattr(beam, "angular_correction", None)
+    if angular_correction is None:
+        dynamic_focus = None
+        tilt_correction = None
+    else: 
+        dynamic_focus = bool(angular_correction.dynamic_focus.is_on)
+        tilt_correction = bool(angular_correction.tilt_correction.is_on)
+
     active_settings = tbt.BeamSettings(
         voltage_kv=voltage_kv,
         current_na=current_na,
@@ -226,6 +234,8 @@ def active_beam_with_settings(
         working_dist_mm=working_dist_mm,
         voltage_tol_kv=voltage_tol_kv,
         current_tol_na=current_tol_na,
+        dynamic_focus=dynamic_focus,
+        tilt_correction=tilt_correction,
     )
 
     return type(selected_beam)(settings=active_settings)


### PR DESCRIPTION
Resolves: #127
Closes: #127 

This pull request fixes an issue where active imaging settings pulled from the microscope do not include angular correction parameters (tilt correction and dynamic focus). Now, those parameters are included and the configuration file accurately shows whether or not the active settings have angular corrections applied.

This was tested for imaging, fib, and ebsd step types. Note that fib does not have angular corrections, so the code handles this by passing "None" to those settings for a fib step.