### PR TITLE
Remove force-include settings from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,6 @@ local_scheme = "no-local-version"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pytribeam"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/pytribeam/GUI/resources" = "pytribeam/GUI/resources"
-
-[tool.hatch.build.targets.sdist.force-include]
-"src/pytribeam/GUI/resources" = "src/pytribeam/GUI/resources"
-
 [tool.hatch.build.hooks.vcs]
 version-file = "src/pytribeam/_version.py"
 # By creating the _version.py file, pytrieam can access its own version number at


### PR DESCRIPTION
Removed force-include configurations for wheel and sdist targets.